### PR TITLE
Do not ignore return value of mkdirs()

### DIFF
--- a/src/main/java/se/uu/it/smbugfinder/Demo.java
+++ b/src/main/java/se/uu/it/smbugfinder/Demo.java
@@ -1,7 +1,6 @@
 package se.uu.it.smbugfinder;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -12,6 +11,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -130,18 +130,14 @@ public class Demo {
         }
         StateMachineBugFinder<String, String> modelBugFinder = new StateMachineBugFinder<String, String>(config);
 
-        File dir = new File(outputDirectory);
-        if (dir.mkdirs()) {
-            modelBugFinder.setExporter(new DFAExporter.DirectoryDFAExporter(outputDirectory));
+        Files.createDirectories(Paths.get(outputDirectory));
+        modelBugFinder.setExporter(new DFAExporter.DirectoryDFAExporter(outputDirectory));
 
-            List<StateMachineBug<String,String>> modelBugs = new ArrayList<>();
-            Statistics stats = modelBugFinder.findBugs(bp, sutModelData.model, sutModelData.alphabet, symbolMapping, sut, modelBugs);
-            export(stats, outputDirectory, "statistics.txt");
-            BugReport bugReport = new BugReport(modelBugs);
-            export(bugReport, outputDirectory, "bug_report.txt");
-        } else {
-            System.out.println("Directory cannot be created");
-        }
+        List<StateMachineBug<String,String>> modelBugs = new ArrayList<>();
+        Statistics stats = modelBugFinder.findBugs(bp, sutModelData.model, sutModelData.alphabet, symbolMapping, sut, modelBugs);
+        export(stats, outputDirectory, "statistics.txt");
+        BugReport bugReport = new BugReport(modelBugs);
+        export(bugReport, outputDirectory, "bug_report.txt");
     }
 
     public static void main(String args []) throws IOException {

--- a/src/main/java/se/uu/it/smbugfinder/Main.java
+++ b/src/main/java/se/uu/it/smbugfinder/Main.java
@@ -10,6 +10,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,44 +71,40 @@ public class Main {
     }
 
     private static void launchBugFinder(StateMachineBugFinderToolConfig config) throws FileNotFoundException, IOException {
-        File dir = new File(config.getOutputDir());
-        if (dir.mkdirs()) {
-            InputModelDeserializer<@Nullable String, CompactMealy<@Nullable String, @Nullable String>> mealyParser = DOTParsers.mealy();
-            InputModelData<@Nullable String, CompactMealy<@Nullable String, @Nullable String>> sutModelData = mealyParser.readModel(getResource(config.getModel()));
+        Files.createDirectories(Paths.get(config.getOutputDir()));
+        InputModelDeserializer<@Nullable String, CompactMealy<@Nullable String, @Nullable String>> mealyParser = DOTParsers.mealy();
+        InputModelData<@Nullable String, CompactMealy<@Nullable String, @Nullable String>> sutModelData = mealyParser.readModel(getResource(config.getModel()));
 
-            BugPatternLoader loader = new BugPatternLoader(new DefaultDFADecoder());
+        BugPatternLoader loader = new BugPatternLoader(new DefaultDFADecoder());
 
-            SymbolMapping<String, String> symbolMapping = new StringSymbolMapper(config.getEmptyOutput(), config.getSeparator());
-            List<Symbol> allSymbols = new ArrayList<>();
-            SUT<String,String> sut = null;
-            MealySymbolExtractor.extractSymbols(sutModelData.model, sutModelData.alphabet, symbolMapping, allSymbols);
-            BugPatterns bp = loader.loadPatterns(config.getPatterns(), allSymbols);
-            StateMachineBugFinderConfig finderConfig = config.getSmBugFinderConfig();
-            if (finderConfig.isValidate()) {
-                if (config.getHarnessAddress() != null) {
-                    String[] hostPort = config.getHarnessAddress().split("\\:");
-                    String host = hostPort[0];
-                    int port = Integer.parseInt(hostPort[1]);
-                    Socket socket = new Socket(host, port);
-                    sut = new SocketSUT(socket, config.getResetMessage(), config.getResetConfirmationMessage());
-                } else if (config.getValidationModel() != null) {
-                    InputModelData<@Nullable String, CompactMealy<@Nullable String, @Nullable String>> validationModelPath = mealyParser.readModel(getResource(config.getValidationModel()));
-                    sut = new SimulatedMealySUT<String, String>(validationModelPath.model);
-                } else {
-                    throw new ConfigurationException("Unable to validate since neither the address of a test harness nor a validation model were provided");
-                }
+        SymbolMapping<String, String> symbolMapping = new StringSymbolMapper(config.getEmptyOutput(), config.getSeparator());
+        List<Symbol> allSymbols = new ArrayList<>();
+        SUT<String,String> sut = null;
+        MealySymbolExtractor.extractSymbols(sutModelData.model, sutModelData.alphabet, symbolMapping, allSymbols);
+        BugPatterns bp = loader.loadPatterns(config.getPatterns(), allSymbols);
+        StateMachineBugFinderConfig finderConfig = config.getSmBugFinderConfig();
+        if (finderConfig.isValidate()) {
+            if (config.getHarnessAddress() != null) {
+                String[] hostPort = config.getHarnessAddress().split("\\:");
+                String host = hostPort[0];
+                int port = Integer.parseInt(hostPort[1]);
+                Socket socket = new Socket(host, port);
+                sut = new SocketSUT(socket, config.getResetMessage(), config.getResetConfirmationMessage());
+            } else if (config.getValidationModel() != null) {
+                InputModelData<@Nullable String, CompactMealy<@Nullable String, @Nullable String>> validationModelPath = mealyParser.readModel(getResource(config.getValidationModel()));
+                sut = new SimulatedMealySUT<String, String>(validationModelPath.model);
+            } else {
+                throw new ConfigurationException("Unable to validate since neither the address of a test harness nor a validation model were provided");
             }
-
-            StateMachineBugFinder<String, String> modelBugFinder = new StateMachineBugFinder<String, String>(finderConfig);
-            modelBugFinder.setExporter(new DFAExporter.DirectoryDFAExporter(config.getOutputDir()));
-            List<StateMachineBug<String,String>> modelBugs = new ArrayList<>();
-            Statistics stats = modelBugFinder.findBugs(bp, sutModelData.model, sutModelData.alphabet, symbolMapping, sut, modelBugs);
-            export(stats, config.getOutputDir(), "statistics.txt");
-            BugReport bugReport = new BugReport(modelBugs);
-            export(bugReport, config.getOutputDir(), "bug_report.txt");
-        } else {
-            System.out.println("Directory cannot be created");
         }
+
+        StateMachineBugFinder<String, String> modelBugFinder = new StateMachineBugFinder<String, String>(finderConfig);
+        modelBugFinder.setExporter(new DFAExporter.DirectoryDFAExporter(config.getOutputDir()));
+        List<StateMachineBug<String,String>> modelBugs = new ArrayList<>();
+        Statistics stats = modelBugFinder.findBugs(bp, sutModelData.model, sutModelData.alphabet, symbolMapping, sut, modelBugs);
+        export(stats, config.getOutputDir(), "statistics.txt");
+        BugReport bugReport = new BugReport(modelBugs);
+        export(bugReport, config.getOutputDir(), "bug_report.txt");
     }
 
     private static void export(ExportableResult result, String outputDirectory, String filename) throws FileNotFoundException {


### PR DESCRIPTION
`mkdirs()` may (in exceptional cases) fail to create a directory, in which case it returns `false`.
Rather than ignoring these cases, use methods from `java.nio.file.Files` package, which throws `IOException` in such cases.