### PR TITLE
Bug pattern catalogue specified directly as XML file instead of as folder containing an XML file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Suppose we want to test the SSH server implementation of [Dropbear][dropbear] V2
 From within **SMBugFinder**'s directory, we then run:
 
     > mvn install
-    > java -jar target/sm-bug-finder.jar -m src/main/resources/models/ssh/server/Dropbear-v2020.81.dot -p src/main/resources/patterns/ssh/server/ -eo NO_RESP
+    > java -jar target/sm-bug-finder.jar -m src/main/resources/models/ssh/server/Dropbear-v2020.81.dot -c src/main/resources/patterns/ssh/server/patterns.xml -eo NO_RESP
 
 First command installs **SMBugFinder**.
 Second command executes **SMBugFinder** using two mandatory arguments, and an optional one:
@@ -67,7 +67,7 @@ See the respective fuzzer repositories for scripts to trim the models.
 
 ## Bug patterns
 
-**SMBugFinder** takes as argument the path to a folder containing bug paterns, which form our bug pattern catalogue.
+**SMBugFinder** takes as argument the path to a bug pattern catalogue which indexes bug patterns.
 Bug patterns are specified as DOT graphs, and currently have to be manually written.
 A bug pattern defines a DFA which accepts only sequences exposing the presence of the bug.
 The directory [src/main/resources/models](src/main/resources/models) contains an extensive set of bug patterns for SSH (including all used in the NDSS'2023 paper), and a few bug patterns for DTLS.
@@ -97,8 +97,7 @@ __start0 -> start;
 }
 ```
 
-The bug pattern folder must also include a mandatory `patterns.xml` file.
-This file specifies the bug patterns to check and information on them (e.g., name, bug severity).
+This bug pattern catalogue is given in XML, and specifies the bug patterns to check and information on them (e.g., name, bug severity).
 Below is the excerpt specifying the  *Missing SR_AUTH* bug pattern:
 
 ```xml
@@ -120,11 +119,11 @@ Validation is disabled by default, and can be enabled via the `-vb` option.
 Suppose that our test harness for SSH listens at address `localhost:7000`.
 To run bug detection on Dropbear with validation enabled, one would run[^1]:
 
-    > java -jar target/sm-bug-finder.jar -m /models/ssh/server/Dropbear-v2020.81.dot -p /patterns/ssh/server/ -vb -ha localhost:7000
+    > java -jar target/sm-bug-finder.jar -m /models/ssh/server/Dropbear-v2020.81.dot -c /patterns/ssh/server/patterns.xml -vb -ha localhost:7000
 
 ## Arguments
 
-**SMBugFinder** supports many other useful options, e.g., for configuring the algorithm used to generate witnesses.
+**SMBugFinder** supports many other options, e.g., for configuring the algorithm used to generate witnesses.
 For a full list of options run:
 
     > java -jar target/sm-bug-finder.jar
@@ -144,7 +143,7 @@ Below is an an example which includes some of the arguments we have just covered
 * [DTLS-Fuzzer][dtlsfuzzer], [EDHOC-Fuzzer][edhocfuzzer] and [SSH-Fuzzer][sshfuzzer], fuzzers for DTLS, EDHOC and SSH (the latter is WIP) which can generate SUT models.
 
 [^1]:For convenience, **SMBugFinder** resolves `/models/ssh/Dropbear-v2020.81.dot` and `src/main/resources/models/ssh/Dropbear-v2020.81.dot` to the same file. When resolving a path starting with `/`, **SMBugFinder** first checks it in its source directories (e.g., `src/main/resources/`), and only if unsuccessful, in the root directory.
-[^2]:Note that **SMBugFinder** has seen significant updates since the artifact. We cannot guarantee compatibility with the version that was used in the artifact.
+[^2]:Note that **SMBugFinder** has seen significant updates since the artifact. As a result, it is no longer compatible with the version that was used in the artifact.
 
 
 [ndss23paper]:https://www.ndss-symposium.org/wp-content/uploads/2023/02/ndss2023_s68_paper.pdf

--- a/src/main/java/se/uu/it/smbugfinder/Main.java
+++ b/src/main/java/se/uu/it/smbugfinder/Main.java
@@ -118,7 +118,7 @@ public class Main {
             }
         }
 
-        StateMachineBugFinder<String, String> modelBugFinder = new StateMachineBugFinder<String, String>(finderConfig);
+        StateMachineBugFinder<String, String> modelBugFinder = new StateMachineBugFinder<>(finderConfig);
         if (exporter != null) {
             modelBugFinder.setExporter(exporter);
         }

--- a/src/main/java/se/uu/it/smbugfinder/StateMachineBugFinderConfig.java
+++ b/src/main/java/se/uu/it/smbugfinder/StateMachineBugFinderConfig.java
@@ -19,7 +19,7 @@ public class StateMachineBugFinderConfig {
     private SearchConfig searchConfig;
 
     @Parameter(names = {"-vb", "-validateBugs"}, required = false,
-               description = "Validate the bugs found. Validation requires either an online test harness or a Mealy machine.")
+               description = "Validate the bugs found. Validation requires either an online test harness or a Mealy machine which simulates the SUT.")
     private boolean validate = false;
 
     @Parameter(names = { "-vtl", "-validationTimeLimit" }, required = false,

--- a/src/main/java/se/uu/it/smbugfinder/StateMachineBugFinderToolConfig.java
+++ b/src/main/java/se/uu/it/smbugfinder/StateMachineBugFinderToolConfig.java
@@ -5,27 +5,27 @@ import com.beust.jcommander.ParametersDelegate;
 
 public class StateMachineBugFinderToolConfig {
 
-    @Parameter(names = {"-m", "-model"}, required = true, description = "The SUT Mealy machine on which bug (pattern) detection is performed. ")
+    @Parameter(names = {"-m", "-model"}, required = true, description = "Mealy machine of the SUT in DOT format with which bug detection is performed.")
     private String model;
 
-    @Parameter(names = {"-p", "-patterns"}, required = true, description = "A directory containing bug patterns, which includes the corresponding .dot models plus a patterns.xml for cataloguing them. ")
+    @Parameter(names = {"-c", "-catalogue"}, required = true, description = "XML file which catalogues DFA-encoded bug patterns, expressed in DOT format.")
     private String patterns;
 
-    @Parameter(names = {"-ha", "-harnessAddress"}, required = false, description = "The listening address of the test harness used to validate bugs. "
+    @Parameter(names = {"-ha", "-harnessAddress"}, required = false, description = "Listening address of the test harness used to validate bugs. "
             + "The harness should be able to apply inputs on the SUT, retrieve its outputs and reset it.")
     private String harnessAddress;
 
-    @Parameter(names = {"-vm", "-validationModel"}, required = false, description = "Mealy machine which is simulated and used to validate bugs.")
+    @Parameter(names = {"-vm", "-validationModel"}, required = false, description = "Mealy machine in DOT format used to simulate a SUT.")
     private String validationModel;
 
     @Parameter(names = {"-os", "-outputSeparator"}, required = false, description = "Separator used to split compound outputs into atomic outputs.")
     private String separator = "+";
 
-    @Parameter(names = {"-eo", "-emptyOutput"}, required = false, description = "The string corresponding to the empty output."
+    @Parameter(names = {"-eo", "-emptyOutput"}, required = false, description = "String corresponding to the empty output."
             + "An empty output is mapped to an empty set of DFA symbols. ")
     private String emptyOutput = "TIMEOUT";
 
-    @Parameter(names = {"-od", "-outputDir"}, required = false, description = "Directory to export dfa models, statistics and the bug report to.")
+    @Parameter(names = {"-od", "-outputDir"}, required = false, description = "Directory to export DFA models, statistics and the bug report to.")
     private String outputDir = "output";
 
     @Parameter(names = {"-rm", "-resetMessage"}, required = false, description = "Message to send to the test harness in order to reset the SUT.")

--- a/src/main/java/se/uu/it/smbugfinder/pattern/BugPatterns.java
+++ b/src/main/java/se/uu/it/smbugfinder/pattern/BugPatterns.java
@@ -50,7 +50,7 @@ public class BugPatterns {
         removeDisabled();
     }
 
-    /*
+    /**
      * Adjusts the contained bug patterns according to the default values of this container.
      */
     private void updateDefaults() {
@@ -64,7 +64,7 @@ public class BugPatterns {
         }
     }
 
-    /*
+    /**
      * Removes bug patterns that have not been enabled
      */
     private void removeDisabled() {
@@ -73,7 +73,7 @@ public class BugPatterns {
         this.bugPatterns = bugPatterns;
     }
 
-    /*
+    /**
      * Removes bug patterns for which the selector returns false.
      */
     public void applySelector(Predicate<BugPattern> selector) {

--- a/src/test/java/se/uu/it/smbugfinder/bugfinding/DtlsBugFindingTest.java
+++ b/src/test/java/se/uu/it/smbugfinder/bugfinding/DtlsBugFindingTest.java
@@ -11,9 +11,9 @@ import se.uu.it.smbugfinder.StateMachineBugFinderToolConfig;
 
 public class DtlsBugFindingTest extends BugFindingTest {
     public static final String DTLS_CLIENT_MODEL = "/models/dtls/client/MbedTLS-2.26.0_client_psk_reneg.dot";
-    public static final String DTLS_CLIENT_BUG_PATTERNS = "/patterns/dtls/client/";
+    public static final String DTLS_CLIENT_BUG_PATTERNS = "/patterns/dtls/client/patterns.xml";
     public static final String DTLS_SERVER_MODEL = "/models/dtls/server/MbedTLS-2.26.0_server_all_cert_req.dot";
-    public static final String DTLS_SERVER_BUG_PATTERNS = "/patterns/dtls/server/";
+    public static final String DTLS_SERVER_BUG_PATTERNS = "/patterns/dtls/server/patterns.xml";
 
     @Test
     public void testDtlsClient() throws FileNotFoundException, IOException {

--- a/src/test/java/se/uu/it/smbugfinder/bugfinding/SshBugFindingTest.java
+++ b/src/test/java/se/uu/it/smbugfinder/bugfinding/SshBugFindingTest.java
@@ -18,7 +18,7 @@ import se.uu.it.smbugfinder.bug.StateMachineBug;
  */
 public class SshBugFindingTest extends BugFindingTest {
     private static final String SSH_SERVER_MODEL_FOLDER = "/models/ssh/server/";
-    private static final String SSH_SERVER_BUG_PATTERNS = "/patterns/ssh/server/";
+    private static final String SSH_SERVER_BUG_PATTERNS = "/patterns/ssh/server/patterns.xml";
     private static final String SSH_EMPTY_OUTPUT = "NO_RESP";
 
     private String sshServerModel(String sut) {


### PR DESCRIPTION
As a result of this change, the bug pattern catalogue is specified via `-c` option as an XML file with references/descriptions of all the bug patterns.  This replaces specifying the catalogue as a folder containing this XML file.